### PR TITLE
Adding OSGi Manifest headers with maven-bundle-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,8 +87,23 @@
 				<configuration>
 					<archive>
 						<addMavenDescriptor>false</addMavenDescriptor>
+						<manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
 					</archive>
 				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<version>3.0.1</version>
+				<executions>
+					<execution>
+						<id>bundle-manifest</id>
+						<phase>process-classes</phase>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
Please also upgrade the version of java-utils-data-fetcher to a version that
contains the [OSGi Manifest Header PR](https://github.com/markenwerk/java-utils-data-fetcher/pull/2).
