### PR TITLE
Handle multiple strings in DNS TXT records

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 .classpath
 .checkstyle
 
+.idea
+*.iml

--- a/src/main/java/net/markenwerk/utils/mail/dkim/DomainKeyUtil.java
+++ b/src/main/java/net/markenwerk/utils/mail/dkim/DomainKeyUtil.java
@@ -45,6 +45,7 @@
  */
 package net.markenwerk.utils.mail.dkim;
 
+import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;
 import javax.naming.directory.Attribute;
 import javax.naming.directory.Attributes;
@@ -201,8 +202,14 @@ public final class DomainKeyUtil {
 				throw new DkimException("There is no TXT record available for " + recordName);
 			}
 
-			String value = (String) txtRecord.get();
-			if (null == value) {
+			StringBuilder builder = new StringBuilder();
+			NamingEnumeration e = txtRecord.getAll();
+			while (e.hasMore()) {
+				builder.append((String) e.next());
+			}
+
+			String value = builder.toString();
+			if (value.isEmpty()) {
 				throw new DkimException("Value of RR " + recordName + " couldn't be retrieved");
 			}
 			return value;


### PR DESCRIPTION
A TXT record is allowed to be larger than 255 chars, but to obtain this, we compose the record of multiple strings, like `"string1" "string2" "stringn"`, which must be represented as `string1string2stringn`. Before, it would be represented as `string1" string2 stringn`, which means the public key would be shown as invalid.

This patch concats the DNS TXT records to above format. This will allow key sizes of more than 1024-bit, which is recommended.