### PR TITLE
Fix relaxed header canonicalization.

### DIFF
--- a/src/main/java/net/markenwerk/utils/mail/dkim/Canonicalization.java
+++ b/src/main/java/net/markenwerk/utils/mail/dkim/Canonicalization.java
@@ -91,7 +91,7 @@ public enum Canonicalization {
 		public String canonicalizeHeader(String name, String value) {
 			name = name.trim().toLowerCase();
 			value = value.replaceAll("\\s+", " ").trim();
-			return name + ": " + value;
+			return name + ":" + value;
 		}
 
 		public String canonicalizeBody(String body) {


### PR DESCRIPTION
We were running into occasional DKIM validation issues while using simple canonicalization, but switching to relaxed/relaxed caused just plain rejections everytime. I checked the code with the specs and found an important difference. All tests we've done after this fix validated correctly(via mail-tester.com and emails sent to gmail accounts).

The following item was not respected by the old code:
http://dkim.org/specs/rfc4871-dkimbase.html section 3.4.2:
"Delete any WSP characters remaining before and after the colon separating the header field name from the header field value."