### PR TITLE
Update from Javax Mail to Jakarta Mail

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,8 +76,8 @@
 
 		<dependency>
 			<groupId>com.sun.mail</groupId>
-			<artifactId>javax.mail</artifactId>
-			<version>1.6.2</version>
+			<artifactId>jakarta.mail</artifactId>
+			<version>[1.6.3,)</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Javax Mail has been archived and [officially moved](https://eclipse-ee4j.github.io/javamail/#Latest_News) to Eclipse Foundation.

In order to allow projects to make the switch, this library too should stop relying on the archived project.

It would be great if you would accept this update and release asap, so I can [service my users](https://github.com/bbottema/simple-java-mail/issues/213) as well. 👍 