### PR TITLE
Put junit in test scope and fix tests by not using default instance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,7 @@
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>4.12</version>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 
@@ -103,9 +104,9 @@
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>2.22.2</version>
 				<configuration>
-					<includes>
-						<exclude>**/*Tests.java</exclude>
-					</includes>
+					<systemProperties>
+						<user.timezone>UTC</user.timezone>
+					</systemProperties>
 				</configuration>
 			</plugin>
 

--- a/src/test/java/net/markenwerk/utils/mail/dkim/DkimMessageTest.java
+++ b/src/test/java/net/markenwerk/utils/mail/dkim/DkimMessageTest.java
@@ -100,7 +100,7 @@ public class DkimMessageTest {
 		properties.setProperty("mail.from", "foo@exapmle.com");
 		properties.setProperty("mail.smtp.from", "exapmle.com");
 
-		Session session = Session.getDefaultInstance(properties);
+		Session session = Session.getInstance(properties);
 
 		MimeMessage mimeMessage = new MimeMessage(session) {
 

--- a/src/test/java/net/markenwerk/utils/mail/dkim/DomainKeyTest.java
+++ b/src/test/java/net/markenwerk/utils/mail/dkim/DomainKeyTest.java
@@ -73,7 +73,7 @@ public class DomainKeyTest {
 		Properties properties = new Properties();
 		properties.setProperty("mail.smtp.host", "localhost");
 
-		Session session = Session.getDefaultInstance(properties);
+		Session session = Session.getInstance(properties);
 
 		MimeMessage mimeMessage = new MimeMessage(session);
 		mimeMessage.setRecipient(Message.RecipientType.TO, new InternetAddress("test@exapmle.com"));


### PR DESCRIPTION
I got a junit package in our dependency list and it turns out this library adding that to the dependency. This PR changes it to the proper test scope.

When I was trying to test if it still worked I didn't saw any test ran. And when I removed the exclusion, the tests failed in my terminal for two reasons:

1. The timezone was not set at UTC
2. The DomainKeyTest is interfering with DkimMessageTest by using getDefaultInstance.

I fixed those as well.