### PR TITLE
Bump jakarta.mail to 2.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,8 +57,8 @@
 		<scm.comment>Javadoc for ${project.artifactId}:${project.version}</scm.comment>
 		<connections.github>scm:git:github:${project.identifier}.git</connections.github>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>1.7</maven.compiler.source>
-		<maven.compiler.target>1.7</maven.compiler.target>
+		<maven.compiler.source>1.8</maven.compiler.source>
+		<maven.compiler.target>1.8</maven.compiler.target>
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
 		<dependency>
 			<groupId>com.sun.mail</groupId>
 			<artifactId>jakarta.mail</artifactId>
-			<version>1.6.4</version>
+			<version>2.0.0</version>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/net/markenwerk/utils/mail/dkim/DkimMessage.java
+++ b/src/main/java/net/markenwerk/utils/mail/dkim/DkimMessage.java
@@ -23,9 +23,9 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Enumeration;
 
-import javax.mail.MessagingException;
-import javax.mail.internet.MimeMessage;
-import javax.mail.internet.MimeUtility;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import jakarta.mail.internet.MimeUtility;
 
 import com.sun.mail.smtp.SMTPMessage;
 

--- a/src/main/java/net/markenwerk/utils/mail/dkim/DkimSigner.java
+++ b/src/main/java/net/markenwerk/utils/mail/dkim/DkimSigner.java
@@ -48,8 +48,8 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.regex.Pattern;
 
-import javax.mail.Header;
-import javax.mail.MessagingException;
+import jakarta.mail.Header;
+import jakarta.mail.MessagingException;
 
 import com.sun.mail.util.CRLFOutputStream;
 import com.sun.mail.util.QPEncoderStream;

--- a/src/main/java/net/markenwerk/utils/mail/dkim/DkimSigningException.java
+++ b/src/main/java/net/markenwerk/utils/mail/dkim/DkimSigningException.java
@@ -19,7 +19,7 @@ package net.markenwerk.utils.mail.dkim;
 
 import java.io.IOException;
 
-import javax.mail.MessagingException;
+import jakarta.mail.MessagingException;
 
 /**
  * A {@link MessagingException} that is used to indicate DKIM specific

--- a/src/test/java/net/markenwerk/utils/mail/dkim/DkimMessageTest.java
+++ b/src/test/java/net/markenwerk/utils/mail/dkim/DkimMessageTest.java
@@ -9,11 +9,11 @@ import java.util.Date;
 import java.util.Properties;
 import java.util.Random;
 
-import javax.mail.Message;
-import javax.mail.MessagingException;
-import javax.mail.Session;
-import javax.mail.internet.InternetAddress;
-import javax.mail.internet.MimeMessage;
+import jakarta.mail.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.Session;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/net/markenwerk/utils/mail/dkim/DomainKeyTest.java
+++ b/src/test/java/net/markenwerk/utils/mail/dkim/DomainKeyTest.java
@@ -11,10 +11,10 @@ import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.mail.Message;
-import javax.mail.Session;
-import javax.mail.internet.InternetAddress;
-import javax.mail.internet.MimeMessage;
+import jakarta.mail.Message;
+import jakarta.mail.Session;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
 
 import org.junit.Test;
 


### PR DESCRIPTION
> October 23, 2020 - Jakarta Mail 2.0.0 Final Release
Jakarta Mail 2.0.0 release is the first release with package namespace changed to jakarta.mail. The main jar file is located at com.sun.mail:jakarta.mail.
> This release contains no other enhancements nor bug fixes, except for the minimal required Java SE version which is now Java SE 8. This is also the release included in Jakarta EE 9. Applications are able to switch to this new version by just changing all imports that use javax.mail.* to instead use jakarta.mail.*.
> 
> From https://eclipse-ee4j.github.io/mail/